### PR TITLE
memset is now called for newly allocated buffers

### DIFF
--- a/src/common/bit_util.rs
+++ b/src/common/bit_util.rs
@@ -156,7 +156,7 @@ mod test {
     buffer.reserve(5);
 
     let mut data = buffer.data_as_mut();
-    assert_eq!(false, get_bit(data, 2));
+
     set_bit(data, 2);
     assert!(get_bit(data, 2));
     clear_bit(data, 2);

--- a/src/memory_pool.rs
+++ b/src/memory_pool.rs
@@ -67,10 +67,10 @@ impl MemoryPool for DefaultMemoryPool {
           if old_size > 0 {
             let copy_len = cmp::min(new_size, old_size) as usize;
             libc::memcpy(p_new_page, p_old_page, copy_len);
-            if new_size > old_size {
-              libc::memset(p_new_page.offset(old_size as isize), 0, (new_size - old_size) as usize);
-            }
             libc::free(p_old_page);
+          }
+          if new_size > old_size {
+            libc::memset(p_new_page.offset(old_size as isize), 0, (new_size - old_size) as usize);
           }
           self.bytes_allocated.fetch_add(new_size - old_size, Ordering::Relaxed);
 

--- a/src/memory_pool.rs
+++ b/src/memory_pool.rs
@@ -69,9 +69,6 @@ impl MemoryPool for DefaultMemoryPool {
             libc::memcpy(p_new_page, p_old_page, copy_len);
             libc::free(p_old_page);
           }
-          if new_size > old_size {
-            libc::memset(p_new_page.offset(old_size as isize), 0, (new_size - old_size) as usize);
-          }
           self.bytes_allocated.fetch_add(new_size - old_size, Ordering::Relaxed);
 
           {


### PR DESCRIPTION
This fixes a bug where memset was only being called if the old buffer size was greater than 0, so newly allocated buffers contained uninitialized memory causing tests to fail (sometimes).